### PR TITLE
fix(prod): use real NEXT_PUBLIC_SUPABASE_ANON_KEY in .env.production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,7 +2,7 @@
 
 # Supabase Configuration (project: abpbvhycqgvgpjvficff)
 NEXT_PUBLIC_SUPABASE_URL=https://abpbvhycqgvgpjvficff.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder_anon_key_to_be_configured
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFicGJ2aHljcWd2Z3BqdmZpY2ZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY4NTgwMzgsImV4cCI6MjA3MjQzNDAzOH0.JBOlFZczD-s-zuZgji5nPZPVD72hpZCezA8tOcdTkwM
 
 # Base URL for webhooks (will be set by Vercel automatically)
 NEXT_PUBLIC_BASE_URL=https://alphogenai.vercel.app


### PR DESCRIPTION
Use the real Supabase anon key in .env.production.
This unblocks production build on Vercel and E2E tests.

Notes:
- Only the *anon* key is added (safe for client). 
- No service role or other secrets are included.