### PR TITLE
fix: exclude API routes from middleware processing to resolve 404 errors

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -85,5 +85,5 @@ export default async function middleware(
 }
 
 export const config = {
-  matcher: ['/((?!.+\\.[\\w]+$|_next|monitoring).*)', '/', '/(api|trpc)(.*)'], // Also exclude tunnelRoute used in Sentry from the matcher
+  matcher: ['/((?!.+\\.[\\w]+$|_next|monitoring|api|trpc).*)', '/'], // Exclude API routes, tunnelRoute used in Sentry, and other static assets
 };


### PR DESCRIPTION
- Remove /(api|trpc)(.*) from middleware matcher
- API routes should not be processed by intlMiddleware
- This resolves 404 errors on production API endpoints