### PR TITLE
feat: add runpod_job_id column to jobs table

### DIFF
--- a/migrations/0003_add_runpod_job_id.sql
+++ b/migrations/0003_add_runpod_job_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS runpod_job_id text;


### PR DESCRIPTION
- Add migration 0003_add_runpod_job_id.sql to create runpod_job_id text column
- Uses IF NOT EXISTS to ensure idempotent migration
- Fixes pipeline failure due to missing column reference in jobs API